### PR TITLE
Fix CC and BCC handling

### DIFF
--- a/src/main/java/org/sonatype/micromailer/imp/DefaultMailSender.java
+++ b/src/main/java/org/sonatype/micromailer/imp/DefaultMailSender.java
@@ -54,7 +54,7 @@ public class DefaultMailSender
             {
                 t.connect();
 
-                t.sendMessage( message, message.getAllRecipients() );
+                t.send( message );
             }
             finally
             {


### PR DESCRIPTION
will no longer stuff all recipients into the TO header.  CC and BCC will work properly now, updated test to validate all recipient headers
