### PR TITLE
Upgrade to javax.mail version 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4.7</version>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
+      <version>1.6.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrades JavaMail to 1.6.1 to pull in various improvements, bug fixes, and security vulnerability remediations:

https://javaee.github.io/javamail/docs/CHANGES.txt

Note that this also changes us over from the old-style `javax.mail:mail` naming convention to the more Maven-appropriate `com.sun.mail:javax.mail` naming.